### PR TITLE
Do away with matching end of group name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
 	group = "com.complexible.airline"
 	sourceCompatibility = '1.8'
 	targetCompatibility = '1.8'
-	version = "0.8.0"
+	version = "0.8.1"
 
 	repositories {
 		mavenCentral()

--- a/src/main/java/io/airlift/command/Help.java
+++ b/src/main/java/io/airlift/command/Help.java
@@ -96,7 +96,7 @@ public class Help implements Runnable, Callable<Void> {
 
         // command in a group?
         for (CommandGroupMetadata group : global.getCommandGroups()) {
-            if (name.endsWith(group.getName())) {
+            if (name.equals(group.getName())) {
                 // general group help or specific command help?
                 if (commandNames.size() == 1) {
                     new CommandGroupUsage().usage(global, group, out);


### PR DESCRIPTION
Was matching catalog and log:
```
stardog $ sa help catalog
NAME
        stardog-admin log - Commands for Stardog access and audit logs

SYNOPSIS
        stardog-admin log { print } [--] [ --text ] [ --json ]
                [ {-f | --field} <field>... ] [ --filter <filter>... ]
                [ {-d | --delimeter} <delimeter> ] [ --tail ] [ {-n | --lines} <lines> ]
                <cmd-args>

        Where command-specific arguments <cmd-args> are:
            print: <log file>...

        See 'stardog-admin help log <command>' for more information on a specific command.
```