### PR TITLE
Add validation for global options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
 	group = "com.complexible.airline"
 	sourceCompatibility = '1.8'
 	targetCompatibility = '1.8'
-	version = "0.8.1"
+	version = "0.8.2"
 
 	repositories {
 		mavenCentral()

--- a/src/main/java/io/airlift/command/Cli.java
+++ b/src/main/java/io/airlift/command/Cli.java
@@ -234,6 +234,13 @@ public class Cli<C>
                 throw new ParseOptionMissingException(option.getOptions().iterator().next());
             }
         }
+
+        for (OptionMetadata optionMetadata : state.getParsedOptions().keys()) {
+            List<OptionMetadata> allOptions = command.getAllOptions();
+            if (!allOptions.contains(optionMetadata)) {
+                throw new ParseGlobalOptionUnexpectedException(optionMetadata);
+            }
+        }
     }
 
     //

--- a/src/test/java/io/airlift/command/CommandTest.java
+++ b/src/test/java/io/airlift/command/CommandTest.java
@@ -36,6 +36,7 @@ import io.airlift.command.args.Arity1;
 import io.airlift.command.args.OptionsRequired;
 import io.airlift.command.command.CommandAdd;
 import io.airlift.command.command.CommandCommit;
+import io.airlift.command.command.CommandMain;
 import io.airlift.command.model.CommandMetadata;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;

--- a/src/test/java/io/airlift/command/command/CommandGroupAnnotationTest.java
+++ b/src/test/java/io/airlift/command/command/CommandGroupAnnotationTest.java
@@ -2,6 +2,7 @@ package io.airlift.command.command;
 
 import java.util.Arrays;
 
+import io.airlift.command.ParseGlobalOptionUnexpectedException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -190,8 +191,54 @@ public class CommandGroupAnnotationTest
                 .build();
 
         Object command = parser.parse("commandWithGroupNames", "-i", "A.java");
-
     }
 
-    
+    @Test
+    public void globalOptionCommandAdd()
+    {
+        Cli<?> parser = Cli.buildCli("junk")
+                           .withCommand(CommandWithGroupAnnotation.class)
+                           .build();
+
+        Object command;
+        command = parser.parse("singleGroup", "add");
+        Assert.assertNotNull(command, "command is null");
+        Assert.assertTrue(command instanceof CommandAdd);
+        CommandAdd commandAdd = (CommandAdd) command;
+        Assert.assertTrue(commandAdd.commandMain == null || !commandAdd.commandMain.verbose);
+
+        command = parser.parse("-v", "singleGroup", "add");
+        Assert.assertNotNull(command, "command is null");
+        Assert.assertTrue(command instanceof CommandAdd);
+        Assert.assertTrue(((CommandAdd) command).commandMain.verbose);
+    }
+
+    @Test
+    public void globalOptionCommandStop()
+    {
+        Cli<?> parser = Cli.buildCli("junk")
+                           .withCommand(CommandWithGroupAnnotation.class)
+                           .build();
+
+        Object command;
+        command = parser.parse("singleGroup", "stop");
+        Assert.assertNotNull(command, "command is null");
+        Assert.assertTrue(command instanceof CommandStop);
+        Assert.assertFalse(((CommandStop) command).verbose);
+
+        command = parser.parse("-v", "singleGroup", "stop");
+        Assert.assertNotNull(command, "command is null");
+        Assert.assertTrue(command instanceof CommandStop);
+        Assert.assertTrue(((CommandStop) command).verbose);
+    }
+
+    @Test(expectedExceptions = ParseGlobalOptionUnexpectedException.class)
+    public void globalOptionCommandStart()
+    {
+        Cli<?> parser = Cli.buildCli("junk")
+                           .withCommand(CommandWithGroupAnnotation.class)
+                           .build();
+
+        parser.parse("-v", "singleGroup", "start");
+    }
 }

--- a/src/test/java/io/airlift/command/command/CommandWithGroupAnnotation.java
+++ b/src/test/java/io/airlift/command/command/CommandWithGroupAnnotation.java
@@ -7,7 +7,8 @@ import io.airlift.command.Command;
 import io.airlift.command.Group;
 import io.airlift.command.Option;
 
-@Group(name = "singleGroup", description = "a single group", defaultCommand = CommandWithGroupAnnotation.class,commands = {CommandAdd.class})
+@Group(name = "singleGroup", description = "a single group", defaultCommand = CommandWithGroupAnnotation.class,
+        commands = { CommandAdd.class, CommandStart.class, CommandStop.class })
 @Command(name = "commandWithGroup", description = "A command with a group annotation")
 public class CommandWithGroupAnnotation
 {


### PR DESCRIPTION
Throw a new exception type when a command doesn't support a global option.