### PR TITLE
Throw error for extra/ignored arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
 	group = "com.complexible.airline"
 	sourceCompatibility = '1.8'
 	targetCompatibility = '1.8'
-	version = "0.8.2"
+	version = "0.8.3"
 
 	repositories {
 		mavenCentral()

--- a/src/main/java/io/airlift/command/Accessor.java
+++ b/src/main/java/io/airlift/command/Accessor.java
@@ -89,7 +89,11 @@ public class Accessor
         return instance;
     }
 
-    public void addValues(Object commandInstance, Iterable<?> values)
+    public void addValues(Object commandInstance, Iterable<?> values) {
+        addValues(commandInstance, values, name);
+    }
+
+    public void addValues(Object commandInstance, Iterable<?> values, String argTitle)
     {
         if (Iterables.isEmpty(values)) {
             return;
@@ -105,6 +109,9 @@ public class Accessor
             Iterables.addAll(collection, values);
         }
         else {
+            if (Iterables.size(values) > 1) {
+                throw new ParseException("Maximum of one argument allowed for argument \"%s\". Actual arguments: %s", argTitle, values);
+            }
             try {
                 field.set(instance, Iterables.getLast(values));
             }

--- a/src/main/java/io/airlift/command/ParserUtil.java
+++ b/src/main/java/io/airlift/command/ParserUtil.java
@@ -62,7 +62,13 @@ public class ParserUtil
         // inject args
         if (arguments != null && parsedArguments != null) {
             for (Accessor accessor : arguments.getAccessors()) {
-                accessor.addValues(commandInstance, parsedArguments);
+                List<String> titles = arguments.getTitle();
+	            if (titles == null || titles.isEmpty()) {
+	                accessor.addValues(commandInstance, parsedArguments);
+	            }
+	            else {
+	                accessor.addValues(commandInstance, parsedArguments, titles.get(0));
+	            }
             }
         }
   

--- a/src/test/java/io/airlift/command/AllTests.java
+++ b/src/test/java/io/airlift/command/AllTests.java
@@ -17,9 +17,14 @@ public class AllTests {
     public void testSuite() {
         TestNG aTestNG = new TestNG();
 
-        aTestNG.setTestClasses(new Class[] { CommandTest.class, io.airlift.command.CommandTest.class,
-                                             ParametersDelegateTest.class, HelpTest.class, GitTest.class, GalaxyCommandLineParser.class,
-                                             CommandGroupAnnotationTest.class });
+        aTestNG.setTestClasses(new Class[] {
+                CommandTest.class,
+                io.airlift.command.CommandTest.class,
+                ParametersDelegateTest.class,
+                HelpTest.class, GitTest.class,
+                GalaxyCommandLineParser.class,
+                CommandGroupAnnotationTest.class
+        });
 
         aTestNG.run();
 

--- a/src/test/java/io/airlift/command/CommandTest.java
+++ b/src/test/java/io/airlift/command/CommandTest.java
@@ -36,7 +36,7 @@ import io.airlift.command.args.Arity1;
 import io.airlift.command.args.OptionsRequired;
 import io.airlift.command.command.CommandAdd;
 import io.airlift.command.command.CommandCommit;
-import io.airlift.command.command.CommandMain;
+import io.airlift.command.args.OneArg;
 import io.airlift.command.model.CommandMetadata;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -382,5 +382,16 @@ public class CommandTest
             public long l;
         }
         singleCommandParser(A.class).parse("-lon", "32");
+    }
+
+    public void oneArgument()
+    {
+        singleCommandParser(OneArg.class).parse("OneArg", "arg1");
+    }
+
+    @Test(expectedExceptions = ParseException.class)
+    public void extraArguments()
+    {
+        singleCommandParser(OneArg.class).parse("OneArg", "arg1", "arg2");
     }
 }

--- a/src/test/java/io/airlift/command/ParametersDelegateTest.java
+++ b/src/test/java/io/airlift/command/ParametersDelegateTest.java
@@ -266,6 +266,79 @@ public class ParametersDelegateTest
     public void conflictingMainParametersAreNotAllowed()
     {
         singleCommandParser(ConflictingMainParametersAreNotAllowed.class).parse("command", "main", "params");
+    }
 
+    // ========================================================================================================================
+
+    @Command(name = "command")
+    public static class DuplicateParentChildParametersAreAllowed
+    {
+        public static class Delegate
+        {
+            @Arguments
+            public List<String> mainParams = newArrayList();
+        }
+
+        @Inject
+        public Delegate delegate = new Delegate();
+
+        @Arguments
+        public List<String> mainParams = newArrayList();
+    }
+
+    @Test
+    public void duplicateParentChildParametersAreAllowed()
+    {
+        DuplicateParentChildParametersAreAllowed value = singleCommandParser(DuplicateParentChildParametersAreAllowed.class).parse("command", "main", "params");
+        Assert.assertEquals(value.mainParams, ImmutableList.of("main", "params"));
+        Assert.assertEquals(value.delegate.mainParams, ImmutableList.of("main", "params"));
+    }
+
+    // ========================================================================================================================
+
+    @Command(name = "command")
+    public static class ConflictingParentChildParametersAreNotAllowed
+    {
+        public static class Delegate
+        {
+            @Arguments
+            public List<String> mainParams = newArrayList();
+        }
+
+        @Inject
+        public Delegate delegate = new Delegate();
+
+        @Arguments
+        public String mainParam;
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void conflictingParentChildParametersAreNotAllowed()
+    {
+        singleCommandParser(ConflictingParentChildParametersAreNotAllowed.class).parse("command", "param");
+    }
+
+    // ========================================================================================================================
+
+    @Command(name = "command")
+    public static class ExtraParametersAreNotAllowed
+    {
+        public static class Delegate
+        {
+            @Arguments
+            public String mainParam;
+        }
+
+        @Inject
+        public Delegate delegate = new Delegate();
+
+        @Arguments
+        public String mainParam;
+    }
+
+    @Test(expectedExceptions = ParseException.class)
+    public void extraParametersAreNotAllowed()
+    {
+        singleCommandParser(ExtraParametersAreNotAllowed.class).parse("command", "main", "params");
     }
 }

--- a/src/test/java/io/airlift/command/args/OneArg.java
+++ b/src/test/java/io/airlift/command/args/OneArg.java
@@ -1,0 +1,14 @@
+package io.airlift.command.args;
+
+import io.airlift.command.Arguments;
+import io.airlift.command.Command;
+
+@Command(name = "OneArg", description = "Command with one argument")
+public class OneArg {
+
+	@Arguments(description = "The single argument")
+	public String arg;
+
+	public OneArg() {
+	}
+}


### PR DESCRIPTION
It's not possible for commands that take only a single arg (`String` vs `List<String>`) to test for extra arguments. This PR is to catch those cases in Airline.

```
$ sa db status foo
Database             : foo
Status               : Online
Approx. size         : 11 triples
Queries              : None running
Open Connections     : 0
Open Transactions    : 0
Query Avg. Time      : 0.01 s
Query Rate           : 0.00 queries/sec
Plans Cached         : 0
Plan Cache Hit Ratio : 0.00%

$ sa db status --server https://doghouse.stardog.cloud:5820 foo
Invalid or missing options:
Maximum of one argument allowed for argument "database". Actual arguments: [--server, https://doghouse.stardog.cloud:5820, foo]
Type 'help db status' for usage information
```