### PR TITLE
Add markdown for groups and globals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
 	group = "com.complexible.airline"
 	sourceCompatibility = '1.8'
 	targetCompatibility = '1.8'
-	version = "0.8.3"
+	version = "0.8.4"
 
 	repositories {
 		mavenCentral()

--- a/src/main/java/io/airlift/command/CommandUsage.java
+++ b/src/main/java/io/airlift/command/CommandUsage.java
@@ -497,7 +497,7 @@ public class CommandUsage
 
         aBuilder.append("# ").append(" `").append(programName).append(" ").append(groupName).append(" ").append(command.getName()).append("` ").append("\n");
         aBuilder.append("## Description\n");
-        aBuilder.append(command.getDescription());
+        aBuilder.append(command.getDescription()).append("\n");
         aBuilder.append("## Usage\n`");
         List<OptionMetadata> options = newArrayList();
         if (programName != null) {

--- a/src/main/java/io/airlift/command/CommandUsage.java
+++ b/src/main/java/io/airlift/command/CommandUsage.java
@@ -12,7 +12,6 @@ import io.airlift.command.model.CommandMetadata;
 import io.airlift.command.model.OptionMetadata;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -51,11 +50,11 @@ public class CommandUsage
     {
         StringBuilder stringBuilder = new StringBuilder();
         usage(programName, groupName, commandName, command, stringBuilder);
-        System.out.println(stringBuilder.toString());
+        System.out.println(stringBuilder);
     }
 
     /**
-     * Store the help in the passed string builder.
+     * Store the help in the passed-in string builder.
      */
     public void usage(@Nullable String programName, @Nullable String groupName, String commandName, CommandMetadata command, StringBuilder out)
     {
@@ -107,7 +106,7 @@ public class CommandUsage
         //
         // OPTIONS
         //
-        if (options.size() > 0 || arguments != null) {
+        if (!options.isEmpty() || arguments != null) {
             options = sortOptions(options);
 
             out.append("OPTIONS").newline();
@@ -168,14 +167,14 @@ public class CommandUsage
 
     private List<OptionMetadata> sortOptions(List<OptionMetadata> options) {
         if (optionComparator != null) {
-            options = new ArrayList<OptionMetadata>(options);
-            Collections.sort(options, optionComparator);
+            options = new ArrayList<>(options);
+            options.sort(optionComparator);
         }
         return options;
     }
 
     public String usageRonn(@Nullable String programName, @Nullable String groupName, CommandMetadata command) {
-        final StringBuilder aBuilder = new StringBuilder("");
+        final StringBuilder aBuilder = new StringBuilder();
 
         final String NEW_PARA = "\n\n";
 
@@ -209,7 +208,7 @@ public class CommandUsage
         if (programName != null) {
             aBuilder.append("`").append(programName).append("`");
             aOptions = command.getGlobalOptions();
-            if (aOptions != null && aOptions.size() > 0) {
+            if (aOptions != null && !aOptions.isEmpty()) {
                 aBuilder.append(" ").append(Joiner.on(" ").join(toSynopsisUsage(sortOptions(aOptions))));
                 options.addAll(aOptions);
             }
@@ -217,7 +216,7 @@ public class CommandUsage
         if (groupName != null) {
             aBuilder.append(" `").append(groupName).append("`");
             aOptions = command.getGroupOptions();
-            if (aOptions != null && aOptions.size() > 0) {
+            if (aOptions != null && !aOptions.isEmpty()) {
                 aBuilder.append(" ").append(Joiner.on(" ").join(toSynopsisUsage(sortOptions(aOptions))));
                 options.addAll(aOptions);
             }
@@ -237,8 +236,7 @@ public class CommandUsage
             aBuilder.append(NEW_PARA).append("## DESCRIPTION").append(NEW_PARA).append(aLongDesc);
         }
 
-
-        if (options.size() > 0 || arguments != null) {
+        if (!options.isEmpty() || arguments != null) {
             aBuilder.append(NEW_PARA).append("## OPTIONS");
             options = sortOptions(options);
 
@@ -297,7 +295,7 @@ public class CommandUsage
     }
 
     public String usageHTML(@Nullable String programName, @Nullable String groupName, CommandMetadata command) {
-        final StringBuilder aBuilder = new StringBuilder("");
+        final StringBuilder aBuilder = new StringBuilder();
 
         final String NEWLINE = "<br/>\n";
         // TODO need boostrap css
@@ -362,7 +360,7 @@ public class CommandUsage
         //
         // OPTIONS
         //
-        if (options.size() > 0 || arguments != null) {
+        if (!options.isEmpty() || arguments != null) {
             options = sortOptions(options);
 
             aBuilder.append(NEWLINE);
@@ -479,16 +477,14 @@ public class CommandUsage
 
     public String usageMD(@Nullable String programName, @Nullable String groupName, CommandMetadata command) {
 
-        final StringBuilder aBuilder = new StringBuilder("");
-        final String br = "<br>";
-        final String np = "<br>\n"; //new paragraph
+        final StringBuilder aBuilder = new StringBuilder();
 
         // for jekyll to pick up these pages on the website
         aBuilder.append("---\n");
         aBuilder.append("layout: default\n");
         aBuilder.append("title: ").append(groupName).append(" ").append(command.getName()).append("\n");
 
-        if (programName.equals("stardog")){
+        if ("stardog".equals(programName)){
             aBuilder.append("grand_parent: ").append("Stardog CLI Reference\n");
         }
         else {
@@ -501,7 +497,7 @@ public class CommandUsage
 
         aBuilder.append("# ").append(" `").append(programName).append(" ").append(groupName).append(" ").append(command.getName()).append("` ").append("\n");
         aBuilder.append("## Description\n");
-        aBuilder.append(command.getDescription()).append(np);
+        aBuilder.append(command.getDescription());
         aBuilder.append("## Usage\n`");
         List<OptionMetadata> options = newArrayList();
         if (programName != null) {
@@ -524,7 +520,7 @@ public class CommandUsage
         }
         aBuilder.append("`\n{: .fs-5}\n");
 
-        if (options.size() > 0 || arguments != null) {
+        if (!options.isEmpty() || arguments != null) {
             options = sortOptions(options);
             aBuilder.append("## Options\n\n");
             aBuilder.append("Name, shorthand | Description \n");
@@ -580,7 +576,7 @@ public class CommandUsage
         return aBuilder.toString();
     }
 
-    private static final String htmlize(final String theStr) {
+    private static String htmlize(final String theStr) {
         return theStr.replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll("\n", "<br/>");
     }
 }

--- a/src/main/java/io/airlift/command/GlobalUsageSummary.java
+++ b/src/main/java/io/airlift/command/GlobalUsageSummary.java
@@ -9,7 +9,6 @@ import com.google.common.collect.Iterables;
 import io.airlift.command.model.CommandGroupMetadata;
 import io.airlift.command.model.CommandMetadata;
 import io.airlift.command.model.GlobalMetadata;
-import io.airlift.command.model.OptionMetadata;
 
 import java.util.Collection;
 import java.util.List;
@@ -42,11 +41,11 @@ public class GlobalUsageSummary
     {
         StringBuilder stringBuilder = new StringBuilder();
         usage(global, stringBuilder);
-        System.out.println(stringBuilder.toString());
+        System.out.println(stringBuilder);
     }
 
     /**
-     * Store the help in the passed string builder.
+     * Store the help in the passed-in string builder.
      */
     public void usage(GlobalMetadata global, StringBuilder out)
     {
@@ -61,16 +60,12 @@ public class GlobalUsageSummary
 
         // build arguments
         List<String> commandArguments = newArrayList();
-        Collection<String> args = Collections2.transform(global.getOptions(), new Function<OptionMetadata, String>()
-        {
-            public String apply(OptionMetadata option)
+        Collection<String> args = Collections2.transform(global.getOptions(), option -> {
+            if (option.isHidden())
             {
-                if (option.isHidden())
-                {
-                    return "";
-                }
-                return toUsage(option);
+                return "";
             }
+            return toUsage(option);
         });
         
         commandArguments.addAll(args);
@@ -97,13 +92,7 @@ public class GlobalUsageSummary
         }
 
         out.append("Commands are:").newline();
-        out.newIndentedPrinter(4).appendTable(Iterables.transform(commands.entrySet(), new Function<Entry<String, String>, Iterable<String>>()
-        {
-            public Iterable<String> apply(Entry<String, String> entry)
-            {
-                return ImmutableList.of(entry.getKey(), MoreObjects.firstNonNull(entry.getValue(), ""));
-            }
-        }));
+        out.newIndentedPrinter(4).appendTable(Iterables.transform(commands.entrySet(), (Function<Entry<String, String>, Iterable<String>>) entry -> ImmutableList.of(entry.getKey(), MoreObjects.firstNonNull(entry.getValue(), ""))));
         out.newline();
         out.append("See").append("'" + global.getName()).append("help <command>' for more information on a specific command.").newline();
     }

--- a/src/main/java/io/airlift/command/Help.java
+++ b/src/main/java/io/airlift/command/Help.java
@@ -45,7 +45,7 @@ public class Help implements Runnable, Callable<Void> {
     {
         StringBuilder stringBuilder = new StringBuilder();
         help(command, stringBuilder);
-        System.out.println(stringBuilder.toString());
+        System.out.println(stringBuilder);
     }
 
     public static void help(CommandMetadata command, StringBuilder out) throws UnsupportedOperationException
@@ -57,7 +57,7 @@ public class Help implements Runnable, Callable<Void> {
     {
         StringBuilder stringBuilder = new StringBuilder();
         help(global, commandNames, stringBuilder);
-        System.out.println(stringBuilder.toString());
+        System.out.println(stringBuilder);
     }
 
     public static void help(GlobalMetadata global, List<String> commandNames, StringBuilder out) throws UnsupportedOperationException
@@ -71,7 +71,18 @@ public class Help implements Runnable, Callable<Void> {
 
         // main program?
         if (name.equals(global.getName())) {
-            new GlobalUsage().usage(global, out);
+            if (USAGE_AS_HTML) {
+                throw new UnsupportedOperationException("Global usage not supported in HTML format");
+            }
+            else if (USAGE_AS_RONN) {
+                throw new UnsupportedOperationException("Global usage not supported in RONN format");
+            }
+            else if (USAGE_AS_MD) {
+                out.append(new GlobalUsage().usageMD(global));
+            }
+            else {
+                new GlobalUsage().usage(global, out);
+            }
             return;
         }
 
@@ -99,7 +110,18 @@ public class Help implements Runnable, Callable<Void> {
             if (name.equals(group.getName())) {
                 // general group help or specific command help?
                 if (commandNames.size() == 1) {
-                    new CommandGroupUsage().usage(global, group, out);
+                    if (USAGE_AS_HTML) {
+                        throw new UnsupportedOperationException("Command group usage not supported in HTML format");
+                    }
+                    else if (USAGE_AS_RONN) {
+                        throw new UnsupportedOperationException("Command group usage not supported in RONN format");
+                    }
+                    else if (USAGE_AS_MD) {
+                        out.append(new CommandGroupUsage().usageMD(global, group));
+                    }
+                    else {
+                        new CommandGroupUsage().usage(global, group, out);
+                    }
                     return;
                 }
                 else {

--- a/src/main/java/io/airlift/command/model/CommandGroupMetadata.java
+++ b/src/main/java/io/airlift/command/model/CommandGroupMetadata.java
@@ -10,15 +10,17 @@ public class CommandGroupMetadata
 {
     private final String name;
     private final String description;
-    private final List<OptionMetadata> options;
+	private final String markdownDescription;
+	private final List<OptionMetadata> options;
     private final CommandMetadata defaultCommand;
     private final List<CommandMetadata> commands;
 
-    public CommandGroupMetadata(String name, String description, Iterable<OptionMetadata> options, CommandMetadata defaultCommand, Iterable<CommandMetadata> commands)
+    public CommandGroupMetadata(String name, String description, String markdownDescription, Iterable<OptionMetadata> options, CommandMetadata defaultCommand, Iterable<CommandMetadata> commands)
     {
         this.name = name;
         this.description = description;
-        this.options = ImmutableList.copyOf(options);
+        this.markdownDescription = markdownDescription;
+	    this.options = ImmutableList.copyOf(options);
         this.defaultCommand = defaultCommand;
         this.commands = Lists.newArrayList(commands);
     }
@@ -31,6 +33,11 @@ public class CommandGroupMetadata
     public String getDescription()
     {
         return description;
+    }
+
+    public String getMarkdownDescription()
+    {
+        return markdownDescription;
     }
 
     public List<OptionMetadata> getOptions()
@@ -63,6 +70,9 @@ public class CommandGroupMetadata
         sb.append("CommandGroupMetadata");
         sb.append("{name='").append(name).append('\'');
         sb.append(", description='").append(description).append('\'');
+        if (markdownDescription != null) {
+            sb.append(", markdownDescription='").append(markdownDescription).append('\'');
+        }
         sb.append(", options=").append(options);
         sb.append(", defaultCommand=").append(defaultCommand);
         sb.append(", commands=").append(commands);
@@ -72,12 +82,6 @@ public class CommandGroupMetadata
 
     public static Function<CommandGroupMetadata, String> nameGetter()
     {
-        return new Function<CommandGroupMetadata, String>()
-        {
-            public String apply(CommandGroupMetadata input)
-            {
-                return input.getName();
-            }
-        };
+        return CommandGroupMetadata::getName;
     }
 }

--- a/src/main/java/io/airlift/command/model/CommandMetadata.java
+++ b/src/main/java/io/airlift/command/model/CommandMetadata.java
@@ -144,23 +144,11 @@ public class CommandMetadata
 
     public static Function<CommandMetadata, String> nameGetter()
     {
-        return new Function<CommandMetadata, String>()
-        {
-            public String apply(CommandMetadata input)
-            {
-                return input.getName();
-            }
-        };
+        return CommandMetadata::getName;
     }
 
     public static Function<CommandMetadata, Class> typeGetter()
     {
-        return new Function<CommandMetadata, Class>()
-        {
-            public Class<?> apply(CommandMetadata input)
-            {
-                return input.getType();
-            }
-        };
+        return CommandMetadata::getType;
     }
 }

--- a/src/main/java/io/airlift/command/model/GlobalMetadata.java
+++ b/src/main/java/io/airlift/command/model/GlobalMetadata.java
@@ -7,6 +7,7 @@ import java.util.List;
 public class GlobalMetadata
 {
     private final String name;
+    private final Integer navOrder;
     private final String description;
     private final List<OptionMetadata> options;
     private final CommandMetadata defaultCommand;
@@ -14,13 +15,25 @@ public class GlobalMetadata
     private final List<CommandGroupMetadata> commandGroups;
 
     public GlobalMetadata(String name,
-            String description,
-            Iterable<OptionMetadata> options,
-            CommandMetadata defaultCommand,
-            Iterable<CommandMetadata> defaultGroupCommands,
-            Iterable<CommandGroupMetadata> commandGroups)
+                          String description,
+                          Iterable<OptionMetadata> options,
+                          CommandMetadata defaultCommand,
+                          Iterable<CommandMetadata> defaultGroupCommands,
+                          Iterable<CommandGroupMetadata> commandGroups)
+    {
+        this(name, null, description, options, defaultCommand, defaultGroupCommands, commandGroups);
+    }
+
+    public GlobalMetadata(String name,
+                          Integer navOrder,
+                          String description,
+                          Iterable<OptionMetadata> options,
+                          CommandMetadata defaultCommand,
+                          Iterable<CommandMetadata> defaultGroupCommands,
+                          Iterable<CommandGroupMetadata> commandGroups)
     {
         this.name = name;
+        this.navOrder = navOrder;
         this.description = description;
         this.options = ImmutableList.copyOf(options);
         this.defaultCommand = defaultCommand;
@@ -48,6 +61,9 @@ public class GlobalMetadata
         return defaultCommand;
     }
 
+    /**
+     * Returns commands belonging to the default (command) group.
+     */
     public List<CommandMetadata> getDefaultGroupCommands()
     {
         return defaultGroupCommands;
@@ -71,5 +87,9 @@ public class GlobalMetadata
         sb.append(", commandGroups=").append(commandGroups);
         sb.append('}');
         return sb.toString();
+    }
+
+    public Integer getNavOrder() {
+        return navOrder;
     }
 }

--- a/src/test/java/io/airlift/command/AllTests.java
+++ b/src/test/java/io/airlift/command/AllTests.java
@@ -5,8 +5,6 @@ import org.testng.TestNG;
 import org.testng.annotations.BeforeSuite;
 
 /**
- * <p></p>
- *
  * @author  Michael Grove
  * @since   0.6
  * @version 0.6
@@ -19,9 +17,9 @@ public class AllTests {
 
         aTestNG.setTestClasses(new Class[] {
                 CommandTest.class,
-                io.airlift.command.CommandTest.class,
                 ParametersDelegateTest.class,
-                HelpTest.class, GitTest.class,
+                HelpTest.class,
+                GitTest.class,
                 GalaxyCommandLineParser.class,
                 CommandGroupAnnotationTest.class
         });

--- a/src/test/java/io/airlift/command/HelpTest.java
+++ b/src/test/java/io/airlift/command/HelpTest.java
@@ -44,118 +44,378 @@ import static io.airlift.command.SingleCommand.singleCommand;
 @Test
 public class HelpTest
 {
-	@SuppressWarnings("unchecked")
-	public void testGit()
+    @SuppressWarnings("unchecked")
+    public void testGit()
     {
         CliBuilder<Runnable> builder = Cli.<Runnable>builder("git")
-                .withDescription("the stupid content tracker")
-                .withDefaultCommand(Help.class)
-                .withCommands(Help.class,
-                        Add.class);
+                                          .withDescription("the stupid content tracker")
+                                          .withDefaultCommand(Help.class)
+                                          .withCommands(Help.class,
+                                                        Add.class);
 
         builder.withGroup("remote")
-                .withDescription("Manage set of tracked repositories")
-                .withDefaultCommand(RemoteShow.class)
-                .withCommands(RemoteShow.class,
-                        RemoteAdd.class);
+               .withDescription("Manage set of tracked repositories")
+               .withDefaultCommand(RemoteShow.class)
+               .withCommands(RemoteShow.class,
+                             RemoteAdd.class);
 
         Cli<Runnable> gitParser = builder.build();
 
         StringBuilder out = new StringBuilder();
-        Help.help(gitParser.getMetadata(), ImmutableList.<String>of(), out);
+        Help.help(gitParser.getMetadata(), ImmutableList.of(), out);
         Assert.assertEquals(out.toString(), "usage: git [ -v ] <command> [ <args> ]\n" +
-                "\n" +
-                "Commands are:\n" +
-                "    add      Add file contents to the index\n" +
-                "    help     Display help information\n" +
-                "    remote   Manage set of tracked repositories\n" +
-                "\n" +
-                "See 'git help <command>' for more information on a specific command.\n");
+                                            "\n" +
+                                            "Commands are:\n" +
+                                            "    add      Add file contents to the index\n" +
+                                            "    help     Display help information\n" +
+                                            "    remote   Manage set of tracked repositories\n" +
+                                            "\n" +
+                                            "See 'git help <command>' for more information on a specific command.\n");
 
         out = new StringBuilder();
         Help.help(gitParser.getMetadata(), ImmutableList.of("add"), out);
         Assert.assertEquals(out.toString(), "NAME\n" +
-                "        git add - Add file contents to the index\n" +
-                "\n" +
-                "SYNOPSIS\n" +
-                "        git [ -v ] add [ -i ] [--] [ <patterns>... ]\n" +
-                "\n" +
-                "OPTIONS\n" +
-                "        -i\n" +
-                "            Add modified contents interactively.\n" +
-                "\n" +
-                "        -v\n" +
-                "            Verbose mode\n" +
-                "\n" +
-                "        --\n" +
-                "            This option can be used to separate command-line options from the\n" +
-                "            list of argument, (useful when arguments might be mistaken for\n" +
-                "            command-line options\n" +
-                "\n" +
-                "        <patterns>\n" +
-                "            Patterns of files to be added\n" +
-                "\n");
+                                            "        git add - Add file contents to the index\n" +
+                                            "\n" +
+                                            "SYNOPSIS\n" +
+                                            "        git [ -v ] add [ -i ] [--] [ <patterns>... ]\n" +
+                                            "\n" +
+                                            "OPTIONS\n" +
+                                            "        -i\n" +
+                                            "            Add modified contents interactively.\n" +
+                                            "\n" +
+                                            "        -v\n" +
+                                            "            Verbose mode\n" +
+                                            "\n" +
+                                            "        --\n" +
+                                            "            This option can be used to separate command-line options from the\n" +
+                                            "            list of argument, (useful when arguments might be mistaken for\n" +
+                                            "            command-line options\n" +
+                                            "\n" +
+                                            "        <patterns>\n" +
+                                            "            Patterns of files to be added\n" +
+                                            "\n");
 
         out = new StringBuilder();
         Help.help(gitParser.getMetadata(), ImmutableList.of("remote"), out);
         Assert.assertEquals(out.toString(), "NAME\n" +
-                "        git remote - Manage set of tracked repositories\n" +
-                "\n" +
-                "SYNOPSIS\n" +
-                "        git [ -v ] remote { add | show* } [--] [cmd-options] <cmd-args>\n" +
-                "\n" +
-                "        Where command-specific options [cmd-options] are:\n" +
-                "            add: [ -t <branch> ]\n" +
-                "            show: [ -n ]\n" +
-                "\n" +
-                "        Where command-specific arguments <cmd-args> are:\n" +
-                "            add: [ <name> <url>... ]\n" +
-                "            show: [ <remote> ]\n" +
-                "\n" +
-                "        * show is the default command\n" +
-                "        See 'git help remote <command>' for more information on a specific command.\n" +
-                "OPTIONS\n" +
-                "        -v\n" +
-                "            Verbose mode\n" +
-                "\n");
-//                "COMMANDS\n" +
-//                "        By default, Gives some information about the remote <name>\n" +
-//                "\n" +
-//                "        show\n" +
-//                "            Gives some information about the remote <name>\n" +
-//                "\n" +
-//                "            With -n option, Do not query remote heads\n" +
-//                "\n" +
-//                "        add\n" +
-//                "            Adds a remote\n" +
-//                "\n" +
-//                "            With -t option, Track only a specific branch\n" +
-//                "\n");
-        
+                                            "        git remote - Manage set of tracked repositories\n" +
+                                            "\n" +
+                                            "SYNOPSIS\n" +
+                                            "        git [ -v ] remote { add | show* } [--] [cmd-options] <cmd-args>\n" +
+                                            "\n" +
+                                            "        Where command-specific options [cmd-options] are:\n" +
+                                            "            add: [ -t <branch> ]\n" +
+                                            "            show: [ -n ]\n" +
+                                            "\n" +
+                                            "        Where command-specific arguments <cmd-args> are:\n" +
+                                            "            add: [ <name> <url>... ]\n" +
+                                            "            show: [ <remote> ]\n" +
+                                            "\n" +
+                                            "        * show is the default command\n" +
+                                            "        See 'git help remote <command>' for more information on a specific command.\n" +
+                                            "OPTIONS\n" +
+                                            "        -v\n" +
+                                            "            Verbose mode\n" +
+                                            "\n");
+
         out = new StringBuilder();
         Help.help(gitParser.getMetadata(), ImmutableList.of("remote", "add"), out);
         Assert.assertEquals(out.toString(), "NAME\n" +
-                "        git remote add - Adds a remote\n" +
-                "\n" +
-                "SYNOPSIS\n" +
-                "        git [ -v ] remote add [ -t <branch> ] [--] [ <name> <url>... ]\n" +
-                "\n" +
-                "OPTIONS\n" +
-                "        -t <branch>\n" +
-                "            Track only a specific branch\n" +
-                "\n" +
-                "        -v\n" +
-                "            Verbose mode\n" +
-                "\n" +
-                "        --\n" +
-                "            This option can be used to separate command-line options from the\n" +
-                "            list of argument, (useful when arguments might be mistaken for\n" +
-                "            command-line options\n" +
-                "\n" +
-                "        <name> <url>\n" +
-                "            Name and URL of remote repository to add\n" +
-                "\n"
-                );
+                                            "        git remote add - Adds a remote\n" +
+                                            "\n" +
+                                            "SYNOPSIS\n" +
+                                            "        git [ -v ] remote add [ -t <branch> ] [--] [ <name> <url>... ]\n" +
+                                            "\n" +
+                                            "OPTIONS\n" +
+                                            "        -t <branch>\n" +
+                                            "            Track only a specific branch\n" +
+                                            "\n" +
+                                            "        -v\n" +
+                                            "            Verbose mode\n" +
+                                            "\n" +
+                                            "        --\n" +
+                                            "            This option can be used to separate command-line options from the\n" +
+                                            "            list of argument, (useful when arguments might be mistaken for\n" +
+                                            "            command-line options\n" +
+                                            "\n" +
+                                            "        <name> <url>\n" +
+                                            "            Name and URL of remote repository to add\n" +
+                                            "\n"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGitMd()
+    {
+        CliBuilder<Runnable> builder = Cli.<Runnable>builder("git")
+                                          .withDescription("the stupid content tracker")
+                                          .withDefaultCommand(Help.class)
+                                          .withCommands(Help.class, Add.class);
+
+        builder.withGroup("remote")
+               .withDescription("Manage set of tracked repositories")
+               .withMarkdownDescription("Commands for managing tracked repositories. Read more about [Remote Management](../../git/with-it).")
+               .withDefaultCommand(RemoteShow.class)
+               .withCommands(RemoteShow.class, RemoteAdd.class);
+
+        Cli<Runnable> gitParser = builder.build();
+
+        Help.USAGE_AS_MD = true;
+        try {
+            StringBuilder out = new StringBuilder();
+
+            Help.help(gitParser.getMetadata(), ImmutableList.of("git"), out);
+            Assert.assertEquals(out.toString(),
+                                "---\n" +
+                                "layout: default\n" +
+                                "title: git\n" +
+                                "has_children: true\n" +
+                                "has_toc: false\n" +
+                                "description: This chapter contains details of all git CLI commands.\n" +
+                                "---\n" +
+                                "\n" +
+                                "# git\n" +
+                                "\n" +
+                                "the stupid content tracker\n" +
+                                "\n" +
+                                "Below you'll find all command groups in the `git` client. Select any of the command groups in the table below to view the specific commands in that command group.\n" +
+                                "\n" +
+                                "| Command Group | Description |\n" +
+                                "|---------------|-------------|\n" +
+                                "| [`remote`](./remote) | Manage set of tracked repositories |\n");
+
+            out = new StringBuilder();
+            Help.help(gitParser.getMetadata(), ImmutableList.of("add"), out);
+            Assert.assertEquals(out.toString(),
+                                "---\n" +
+                                "layout: default\n" +
+                                "title: null add\n" +
+                                "grand_parent: Stardog Admin CLI Reference\n" +
+                                "parent: null\n" +
+                                "description: 'Add file contents to the index'\n" +
+                                "---\n" +
+                                "\n" +
+                                "#  `git null add` \n" +
+                                "## Description\n" +
+                                "Add file contents to the index## Usage\n" +
+                                "`git [ -v ] add [ -i ] [--] [ <patterns>... ]`\n" +
+                                "{: .fs-5}\n" +
+                                "## Options\n" +
+                                "\n" +
+                                "Name, shorthand | Description \n" +
+                                "---|---\n" +
+                                "`-i` | Add modified contents interactively.\n" +
+                                "`-v` | Verbose mode\n" +
+                                "`--` | This option can be used to separate command-line options from the list of argument(s). (Useful when an argument might be mistaken for a command-line option)\n" +
+                                "`<patterns>` | Patterns of files to be added\n");
+
+            out = new StringBuilder();
+            Help.help(gitParser.getMetadata(), ImmutableList.of("remote"), out);
+            Assert.assertEquals(out.toString(),
+                                "---\n" +
+                                "layout: default\n" +
+                                "title: remote\n" +
+                                "parent: Stardog Admin CLI Reference\n" +
+                                "has_children: true\n" +
+                                "has_toc: false\n" +
+                                "description: This page contains the commands available in the git remote command group.\n" +
+                                "---\n" +
+                                "\n" +
+                                "# `remote`\n" +
+                                "\n" +
+                                "Commands for managing tracked repositories. Read more about [Remote Management](../../git/with-it).\n" +
+                                "\n" +
+                                "\n" +
+                                "Select any of the commands to view their manual page.\n" +
+                                "\n" +
+                                "| Command | Description |\n" +
+                                "|---------|-------------|\n" +
+                                "| [`remote add`](./remote-add) | Adds a remote |\n" +
+                                "| [`remote show`](./remote-show) | Gives some information about the remote <name> |\n");
+
+            out = new StringBuilder();
+            Help.help(gitParser.getMetadata(), ImmutableList.of("remote", "add"), out);
+            Assert.assertEquals(out.toString(),
+                                "---\n" +
+                                "layout: default\n" +
+                                "title: remote add\n" +
+                                "grand_parent: Stardog Admin CLI Reference\n" +
+                                "parent: remote\n" +
+                                "description: 'Adds a remote'\n" +
+                                "---\n" +
+                                "\n" +
+                                "#  `git remote add` \n" +
+                                "## Description\n" +
+                                "Adds a remote## Usage\n" +
+                                "`git [ -v ] remote  add [ -t <branch> ] [--] [ <name> <url>... ]`\n" +
+                                "{: .fs-5}\n" +
+                                "## Options\n" +
+                                "\n" +
+                                "Name, shorthand | Description \n" +
+                                "---|---\n" +
+                                "`-t <branch>` | Track only a specific branch\n" +
+                                "`-v` | Verbose mode\n" +
+                                "`--` | This option can be used to separate command-line options from the list of argument(s). (Useful when an argument might be mistaken for a command-line option)\n" +
+                                "`<name> <url>` | Name and URL of remote repository to add\n"
+            );
+        }
+        finally {
+            Help.USAGE_AS_MD = false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGitHtml()
+    {
+        CliBuilder<Runnable> builder = Cli.<Runnable>builder("git")
+                                          .withDescription("the stupid content tracker")
+                                          .withDefaultCommand(Help.class)
+                                          .withCommands(Help.class, Add.class);
+
+        builder.withGroup("remote")
+               .withDescription("Manage set of tracked repositories")
+               .withDefaultCommand(RemoteShow.class)
+               .withCommands(RemoteShow.class, RemoteAdd.class);
+
+        Cli<Runnable> gitParser = builder.build();
+
+        Help.USAGE_AS_HTML = true;
+        try {
+            StringBuilder out = new StringBuilder();
+            Help.help(gitParser.getMetadata(), ImmutableList.of("add"), out);
+            Assert.assertEquals(out.toString(),
+                                "<html>\n" +
+                                "<head>\n" +
+                                "<link href=\"css/bootstrap.min.css\" rel=\"stylesheet\" media=\"screen\">\n" +
+                                "</head>\n" +
+                                "<style>\n" +
+                                "    body { margin: 50px; }\n" +
+                                "</style>\n" +
+                                "<body>\n" +
+                                "<hr/>\n" +
+                                "<h1 class=\"text-info\">git null add Manual Page\n" +
+                                "<hr/>\n" +
+                                "<h1 class=\"text-info\">NAME</h1>\n" +
+                                "<br/>\n" +
+                                "<div class=\"row\"><div class=\"span8 offset1\">git null add &mdash;Add file contents to the index</div>\n" +
+                                "</div>\n" +
+                                "<br/>\n" +
+                                "<h1 class=\"text-info\">SYNOPSIS</h1>\n" +
+                                "<br/>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "git [ -v ] add [ -i ] [--] [ &lt;patterns&gt;... ]</div>\n" +
+                                "</div>\n" +
+                                "<br/>\n" +
+                                "<h1 class=\"text-info\">OPTIONS</h1>\n" +
+                                "<br/>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "-i</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "Add modified contents interactively.</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "-v</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "Verbose mode</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "--\n" +
+                                "</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "This option can be used to separate command-line options from the list of argument, (useful when arguments might be mistaken for command-line options\n" +
+                                "</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "&lt;patterns&gt;</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "Patterns of files to be added</div>\n" +
+                                "</div>\n" +
+                                "</body>\n" +
+                                "</html>\n");
+
+            out = new StringBuilder();
+            Help.help(gitParser.getMetadata(), ImmutableList.of("remote", "add"), out);
+            Assert.assertEquals(out.toString(),
+                                "<html>\n" +
+                                "<head>\n" +
+                                "<link href=\"css/bootstrap.min.css\" rel=\"stylesheet\" media=\"screen\">\n" +
+                                "</head>\n" +
+                                "<style>\n" +
+                                "    body { margin: 50px; }\n" +
+                                "</style>\n" +
+                                "<body>\n" +
+                                "<hr/>\n" +
+                                "<h1 class=\"text-info\">git remote add Manual Page\n" +
+                                "<hr/>\n" +
+                                "<h1 class=\"text-info\">NAME</h1>\n" +
+                                "<br/>\n" +
+                                "<div class=\"row\"><div class=\"span8 offset1\">git remote add &mdash;Adds a remote</div>\n" +
+                                "</div>\n" +
+                                "<br/>\n" +
+                                "<h1 class=\"text-info\">SYNOPSIS</h1>\n" +
+                                "<br/>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "git [ -v ] remote  add [ -t &lt;branch&gt; ] [--] [ &lt;name&gt; &lt;url&gt;... ]</div>\n" +
+                                "</div>\n" +
+                                "<br/>\n" +
+                                "<h1 class=\"text-info\">OPTIONS</h1>\n" +
+                                "<br/>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "-t &lt;branch&gt;</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "Track only a specific branch</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "-v</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "Verbose mode</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "--\n" +
+                                "</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "This option can be used to separate command-line options from the list of argument, (useful when arguments might be mistaken for command-line options\n" +
+                                "</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset1\">\n" +
+                                "&lt;name&gt; &lt;url&gt;</div>\n" +
+                                "</div>\n" +
+                                "<div class=\"row\">\n" +
+                                "<div class=\"span8 offset2\">\n" +
+                                "Name and URL of remote repository to add</div>\n" +
+                                "</div>\n" +
+                                "</body>\n" +
+                                "</html>\n"
+            );
+        }
+        finally {
+            Help.USAGE_AS_HTML = false;
+        }
     }
 
     @Test
@@ -451,8 +711,7 @@ public class HelpTest
         CliBuilder<Object> builder = buildCli("test", Object.class)
                 .withDescription("Test commandline")
                 .withDefaultCommand(Help.class)
-                .withCommands(Help.class,
-                        GlobalOptionsHidden.class);
+                .withCommands(Help.class, GlobalOptionsHidden.class);
 
         Cli<Object> parser = builder.build();
 
@@ -482,7 +741,7 @@ public class HelpTest
         Cli<Object> parser = builder.build();
 
         StringBuilder out = new StringBuilder();
-        Help.help(parser.getMetadata(), ImmutableList.<String>of(), out);
+        Help.help(parser.getMetadata(), ImmutableList.of(), out);
         Assert.assertEquals(out.toString(), "usage: test <command> [ <args> ]\n" +
                 "\n" +
                 "Commands are:\n" +
@@ -513,7 +772,7 @@ public class HelpTest
             .build();
 
         StringBuilder out = new StringBuilder();
-        Help.help(parser.getMetadata(), ImmutableList.<String>of("remove"), out);
+        Help.help(parser.getMetadata(), ImmutableList.of("remove"), out);
 
         String discussion = "DISCUSSION\n" +
         "        More details about how this removes files from the index.\n" +
@@ -590,7 +849,7 @@ public class HelpTest
             Assert.fail("Exception should have been thrown for unknown command");
         }
         catch (UnsupportedOperationException e) {
-            Assert.assertEquals("Unknown command asdf", e.getMessage());
+            Assert.assertEquals(e.getMessage(), "Unknown command asdf");
         }
     }
 }

--- a/src/test/java/io/airlift/command/HelpTest.java
+++ b/src/test/java/io/airlift/command/HelpTest.java
@@ -198,7 +198,8 @@ public class HelpTest
                                 "\n" +
                                 "#  `git null add` \n" +
                                 "## Description\n" +
-                                "Add file contents to the index## Usage\n" +
+                                "Add file contents to the index\n" +
+                                "## Usage\n" +
                                 "`git [ -v ] add [ -i ] [--] [ <patterns>... ]`\n" +
                                 "{: .fs-5}\n" +
                                 "## Options\n" +
@@ -247,7 +248,8 @@ public class HelpTest
                                 "\n" +
                                 "#  `git remote add` \n" +
                                 "## Description\n" +
-                                "Adds a remote## Usage\n" +
+                                "Adds a remote\n" +
+                                "## Usage\n" +
                                 "`git [ -v ] remote  add [ -t <branch> ] [--] [ <name> <url>... ]`\n" +
                                 "{: .fs-5}\n" +
                                 "## Options\n" +


### PR DESCRIPTION
Before this commit we were generating markdown for commands only.

This is already built and deployed to jfrog - `com.complexible.airline/airline/0.8.4`

SHA ed99c05a43544e8b2ad53c1c91a09478132c67e6
